### PR TITLE
Use Ampersand to Separate Query Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ The plugin introduces the *!import* statement in your config's *nav* section. Yo
 <details><summary><b>!import Statement Sections</b></summary>
   
   - **{url}**: Only *required* part of *!import* statement (e.g., `https://github.com/{user}/{repo name}`).
-  - **?branch={branch}**: Tells *multirepo* what branch to use. Defaults to *master* if not supplied.
-  - **?docs_dir={path}**: The path to the *docs* directory for the section. Defaults to *docs/\** (a glob) if not supplied.
-  - **?multi_docs={True | False}**: If set to *True*, all *docs* directories will be imported (more info [here](#α-multiple-docs-directories-in-imported-repo-alpha)).
+  - **branch={branch}**: Tells *multirepo* what branch to use. Defaults to *master* if not supplied.
+  - **docs_dir={path}**: The path to the *docs* directory for the section. Defaults to *docs/\** (a glob) if not supplied.
+  - **multi_docs={True | False}**: If set to *True*, all *docs* directories will be imported (more info [here](#α-multiple-docs-directories-in-imported-repo-alpha)).
   - **?config={filename}.yml**: Tells *multirepo* the name of the config file, containing configuration for the plugin. The default value is also `mkdocs.yml`. This config file can live within the docs directory *or* in the parent directory.
 
 </details>
@@ -63,7 +63,7 @@ The plugin introduces the *!import* statement in your config's *nav* section. Yo
 ```yaml
 nav:
   - Home: 'index.md'
-  - MicroService: '!import {url}?branch={branch}?docs_dir={path}?multi_docs={True | False}?config={filename}.yml'
+  - MicroService: '!import {url}?branch={branch}&docs_dir={path}&multi_docs={True | False}&config={filename}.yml'
 ```
 
 *MicroService mkdocs.yml (located within the docs directory or the parent directory)*

--- a/__tests__/fixtures/parent-config-test/mkdocs.yml
+++ b/__tests__/fixtures/parent-config-test/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Test
 
 nav:
   - Home: index.md
-  - section: '!import https://github.com/jdoiro3/mkdocs-multirepo-demoRepo1?branch=ok-with-diff-config-nm-and-loc?config=multirepo.yml'
+  - section: '!import https://github.com/jdoiro3/mkdocs-multirepo-demoRepo1?branch=ok-with-diff-config-nm-and-loc&config=multirepo.yml'
 
 plugins:
   - multirepo

--- a/mkdocs_multirepo_plugin/structure.py
+++ b/mkdocs_multirepo_plugin/structure.py
@@ -6,7 +6,7 @@ from mkdocs.utils import yaml_load
 from mkdocs.structure.files import File
 from .util import (
     ImportDocsException, git_supports_sparse_clone,
-    remove_parents, execute_bash_script
+    remove_parents, execute_bash_script, ImportSyntaxError
 )
 import asyncio
 import tqdm
@@ -33,8 +33,21 @@ def resolve_nav_paths(nav: List[Dict], section_name: str) -> None:
 def parse_repo_url(repo_url: str) -> Dict[str, str]:
     """Parses !import statement urls"""
     url_parts = repo_url.split("?")
-    import_parts = {"url": url_parts[0]}
-    for part in url_parts[1:]:
+    url_parts_len = len(url_parts)
+    if url_parts_len > 2:
+        raise ImportSyntaxError(
+            f"The import statement's repo url, {repo_url}, can only contain one ?"
+            )
+    if url_parts_len == 1:
+        url, query_str = url_parts[0], None
+    else:
+        url, query_str = url_parts[0], url_parts[1]
+    if query_str:
+        query_parts = query_str.split("&")
+    else:
+        query_parts = []
+    import_parts = {"url": url}
+    for part in query_parts:
         k, v = part.split("=")
         import_parts[k] = v
     return import_parts

--- a/mkdocs_multirepo_plugin/util.py
+++ b/mkdocs_multirepo_plugin/util.py
@@ -25,6 +25,10 @@ class GitException(Exception):
     pass
 
 
+class ImportSyntaxError(Exception):
+    pass
+
+
 def get_src_path_root(src_path: str) -> str:
     """returns the root directory of a path (represented as a string)"""
     if "\\" in src_path:

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -7,7 +7,7 @@ import sys
 try:
     from mkdocs_multirepo_plugin import util
     from mkdocs_multirepo_plugin import structure
-except:
+except ModuleNotFoundError:
     subprocess.check_call([sys.executable, "-m", "pip", "install", "."])
     from mkdocs_multirepo_plugin import util
     from mkdocs_multirepo_plugin import structure
@@ -98,10 +98,10 @@ class TestStructure(BaseCase):
         repo_url_cases = [
             (f"{base_url}", {"url": base_url}),
             (f"{base_url}?branch=master", {"url": base_url, "branch": "master"}),
-            (f"{base_url}?branch=main?multi_docs=true", {"url": base_url, "branch": "main", "multi_docs": "true"}),
-            (f"{base_url}?multi_docs=false?branch=main", {"url": base_url, "multi_docs": "false", "branch": "main"}),
+            (f"{base_url}?branch=main&multi_docs=true", {"url": base_url, "branch": "main", "multi_docs": "true"}),
+            (f"{base_url}?multi_docs=false&branch=main", {"url": base_url, "multi_docs": "false", "branch": "main"}),
             (f"{base_url}?docs_dir=fldr/docs/*", {"url": base_url, "docs_dir": "fldr/docs/*"}),
-            (f"{base_url}?multi_docs=false?branch=main?config=multirepo.yml", {"url": base_url, "multi_docs": "false", "branch": "main", "config": "multirepo.yml"}),
+            (f"{base_url}?multi_docs=false&branch=main&config=multirepo.yml", {"url": base_url, "multi_docs": "false", "branch": "main", "config": "multirepo.yml"}),
         ]
         for case in repo_url_cases:
             parsed_url = structure.parse_repo_url(case[0])

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -106,6 +106,8 @@ class TestStructure(BaseCase):
         for case in repo_url_cases:
             parsed_url = structure.parse_repo_url(case[0])
             self.assertDictEqual(parsed_url, case[1])
+        with self.assertRaises(util.ImportSyntaxError):
+            structure.parse_repo_url(f"{base_url}?docs_dir=fldr/docs/*?config=multirepo.yml")
 
     async def test_sparse_clone(self):
         async with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
This new change requires `!import` statements to use the same query string separation as regular URLs.

For example, this

`'!import {url}?branch={branch}?docs_dir={path}?multi_docs={True | False}?config={filename}.yml'`

turns into this

`'!import {url}?branch={branch}&docs_dir={path}&multi_docs={True | False}&config={filename}.yml'`