### PR TITLE
Fix: add python-slugify to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
     install_requires=[
         "mkdocs>=1.0.4",
         "asyncio",
-        "tqdm"
+        "tqdm",
+        "python-slugify"
         ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
With the changes from #28, installing the plugin and trying to run `mkdocs build` results in 

```
ModuleNotFoundError: No module named 'slugify'
```