### PR TITLE
Fix os.system() call on windows

### DIFF
--- a/mkdocs_multirepo_plugin/plugin.py
+++ b/mkdocs_multirepo_plugin/plugin.py
@@ -20,7 +20,7 @@ from slugify import slugify
 if is_windows():
     # allow for ASCII escape codes to be used in terminal
     import os
-    os.system()
+    os.system("")
 
 IMPORT_STATEMENT = "!import"
 DEFAULT_BRANCH = "master"


### PR DESCRIPTION
One of our users reported the plugin is currently broken on Windows - this small change should do the trick. 
Maybe the `os.system()` call comes from https://stackoverflow.com/a/64222858/15836334, but it really does need an argument as shown in the SO answer, even if just an empty string.

/cc @mikedeischle @jdoiro3 