### PR TITLE
fix: expect git and bash in PATH over custom discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [tool.poetry]
 name = "mkdocs-multirepo-plugin"
-version = "0.4.8"
+version = "0.4.9"
 description = "Build documentation in multiple repos into one site."
 authors = ["jdoiro3 <josephdoiron1234@yahoo.com>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         'mkdocs_multirepo_plugin/scripts/sparse_clone_old.sh',
         'mkdocs_multirepo_plugin/scripts/mv_docs_up.sh'
         ],
-    version="0.4.8",
+    version="0.4.9",
     author="Joseph Doiron",
     author_email="josephdoiron1234@yahoo.com",
     description="Build documentation in multiple repos into one site.",


### PR DESCRIPTION
Closes https://github.com/jdoiro3/mkdocs-multirepo-plugin/issues/50.

It's not possible to have git and not have bash on windows, so I've done the same for the `bash` call for simplicity.