### PR TITLE
Allows imported repos in sub menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added support for importing repos into a subsection.
 - Fixed moving the imported docs folder up so that the docs folder does not appear in the menu.
+- MkDocs versions  >= 1.4.0 changed the default config values from an empty string to None. You should use this version or newer to insure support with newer versions of MkDocs.
 
 ## 0.4.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.10
+
+- Added support for importing repos into a subsection.
+- Fixed moving the imported docs folder up so that the docs folder does not appear in the menu.
+
 ## 0.4.8
 
 - Fixed the generation of edit urls for imported repos.

--- a/README.md
+++ b/README.md
@@ -107,10 +107,13 @@ plugins:
         - section: Monorepo Multi Docs
           import_url: https://github.com/backstage/mkdocs-monorepo-plugin?multi_docs=True&docs_dir=sample-docs/*
         - section: 'Django REST'
+          section_path: python # Put this under the python menu entry
           import_url: 'https://github.com/encode/django-rest-framework'
         - section: 'Cookiecutter Pypackage'
+          section_path: python # Put this under the python menu entry
           import_url: 'https://github.com/zillionare/cookiecutter-pypackage'
         - section: 'Pydantic'
+          section_path: python # Put this under the python menu entry
           import_url: 'https://github.com/samuelcolvin/pydantic'
 ```
 

--- a/__tests__/fixtures/parent-with-repos/mkdocs.yml
+++ b/__tests__/fixtures/parent-with-repos/mkdocs.yml
@@ -9,3 +9,6 @@ plugins:
           import_url: https://github.com/jdoiro3/mkdocs-multirepo-demoRepo1?branch=ok-no-nav
         - section: ok-nav-complex
           import_url: https://github.com/jdoiro3/mkdocs-multirepo-demoRepo1?branch=ok-nav-complex
+        - section: ok-sub-section
+          section_path: sub-section/deep
+          import_url: https://github.com/jdoiro3/mkdocs-multirepo-demoRepo1?branch=ok-nav-simple

--- a/__tests__/test.bats
+++ b/__tests__/test.bats
@@ -100,6 +100,8 @@ teardown() {
   outputContains "Welcome to section 1."
   run cat "$parent/site/ok-nav-complex/section2/index.html"
   outputContains "Welcome to section 2."
+  run cat "$parent/site/sub-section/deep/ok-sub-section/index.html"
+  outputContains "Welcome to a simple repo."
 }
 
 @test "Build a mkdocs site with nav section" {

--- a/mkdocs_multirepo_plugin/plugin.py
+++ b/mkdocs_multirepo_plugin/plugin.py
@@ -141,14 +141,16 @@ class MultirepoPlugin(BasePlugin):
             import_stmt = parse_repo_url(repo.get("import_url"))
             if "!import" in import_stmt.get("url"):
                 raise ImportSyntaxError(f"import_url should only contain the url with plugin accepted params. You included '!import'.")
-            if set(repo.keys()).difference({"import_url", "section"}) != set():
+            if set(repo.keys()).difference({"import_url", "section", "section_path"}) != set():
                 raise ReposSectionException(
-                    "Repos section now only supports 'import_url' and 'section'. \
+                    "Repos section now only supports 'import_url', 'section', and 'section_path'. \
                      All other config values should use the nav import url config (i.e., [url]?[key]=[value])"
                     )
             name_slug = slugify(repo.get("section"))
+            path = repo.get("section_path")
+            repo_name = f"{path}/{name_slug}" if path is not None else name_slug
             repo = DocsRepo(
-                name=name_slug,
+                name=repo_name,
                 url=import_stmt.get("url"),
                 temp_dir=self.temp_dir,
                 docs_dir=import_stmt.get("docs_dir", "docs/*"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [tool.poetry]
 name = "mkdocs-multirepo-plugin"
-version = "0.4.9"
+version = "0.4.10"
 description = "Build documentation in multiple repos into one site."
 authors = ["jdoiro3 <josephdoiron1234@yahoo.com>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         'mkdocs_multirepo_plugin/scripts/sparse_clone_old.sh',
         'mkdocs_multirepo_plugin/scripts/mv_docs_up.sh'
         ],
-    version="0.4.9",
+    version="0.4.10",
     author="Joseph Doiron",
     author_email="josephdoiron1234@yahoo.com",
     description="Build documentation in multiple repos into one site.",


### PR DESCRIPTION
When using the automatic file collection of mkdocs instead the defining the nav manually, it would be great to be able to place imported documentation not only on the root level but also nested.

```
repos:
- section: Monorepo
  section_path: Backstage
  import_url: 'https://github.com/backstage/mkdocs-monorepo-plugin'
- section: 'Techdocs-cli'
  section_path: Backstage
  import_url: 'https://github.com/backstage/techdocs-cli'
- section: FastAPI
  import_url: 'https://github.com/tiangolo/fastapi'
```

yielding to

```
├───Backstage
│   └───Monorepo
│   └───Techdocs-cli
├───FastAPI
```

instead of this without the option
```
├───FastAPI
├───Monorepo
├───Techdocs-cli
```