### PR TITLE
Uses the correct GithubAccessToken when building the URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.12
+
+- Fixed use of `GithubAccessToken` environment variable so that the sparse clone now uses the correct token.
+
 ## 0.4.11
 
 - Added a specific `GithubAccessToken` environment variable that allows usage of the plugin with GitHub Apps-generated access tokens and personal access tokens.

--- a/mkdocs_multirepo_plugin/scripts/sparse_clone.sh
+++ b/mkdocs_multirepo_plugin/scripts/sparse_clone.sh
@@ -13,7 +13,7 @@ if [[ -n  "$AccessToken" ]]; then
     url_to_use="${protocol}://$AccessToken@$url_rest"
     git config http.extraheader "AUTHORIZATION: bearer $AccessToken"
 elif [[ -n  "$GithubAccessToken" ]]; then
-    url_to_use="${protocol}://x-access-token:$AccessToken@$url_rest"
+    url_to_use="${protocol}://x-access-token:$GithubAccessToken@$url_rest"
 else
   url_to_use="$url"
 fi

--- a/mkdocs_multirepo_plugin/scripts/sparse_clone_old.sh
+++ b/mkdocs_multirepo_plugin/scripts/sparse_clone_old.sh
@@ -19,7 +19,7 @@ if [[ -n  "$AccessToken" ]]; then
     url_to_use="${protocol}://$AccessToken@$url_rest"
     git config http.extraheader "AUTHORIZATION: bearer $AccessToken"
 elif [[ -n  "$GithubAccessToken" ]]; then
-    url_to_use="${protocol}://x-access-token:$AccessToken@$url_rest"
+    url_to_use="${protocol}://x-access-token:$GithubAccessToken@$url_rest"
 else
   url_to_use="$url"
 fi


### PR DESCRIPTION
The bash script to clone the repos uses now the correct environment variable to build the Github URL with access token.

I am very sorry / embarrassed :) I overlooked one occurrence of the environment variable when rebuilding the script inside the plugin based on my local script.