### PR TITLE
Feature: Add support for nav repos

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ on:
         description: Generate a GH release and create a new tag
         type: boolean
         required: false
-        default: true
+        default: false
       release-to-pypi-override:
         description: Generate a release to PYPI even if the version in pyproject.toml is the same as main
         type: boolean

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
   - repo: local
     hooks:
       - id: unit-tests
+        types: [executable, python]
         name: run unit tests
         entry: python -m unittest tests.unittests
         language: system
@@ -35,6 +36,7 @@ repos:
   - repo: local
     hooks:
       - id: integration-tests
+        types: [executable, python]
         name: run integration tests
         entry: env PYTHON_37_ONLY=1 ./__tests__/test.sh
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,11 @@ repos:
         entry: python -m unittest tests.unittests
         language: system
         pass_filenames: false
+  - repo: local
+    hooks:
+      - id: integration-tests
+        name: run integration tests
+        entry: env PYTHON_37_ONLY=1 ./__tests__/test.sh
+        language: system
+        verbose: true
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
   - repo: local
     hooks:
       - id: unit-tests
-        types: [executable, python]
+        types_or: [executable, python]
         name: run unit tests
         entry: python -m unittest tests.unittests
         language: system
@@ -36,7 +36,7 @@ repos:
   - repo: local
     hooks:
       - id: integration-tests
-        types: [executable, python]
+        types_or: [executable, python]
         name: run integration tests
         entry: env PYTHON_37_ONLY=1 ./__tests__/test.sh
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,5 +40,4 @@ repos:
         name: run integration tests
         entry: env PYTHON_37_ONLY=1 NO_IT=1 ./__tests__/test.sh
         language: system
-        verbose: true
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
       - id: integration-tests
         types_or: [executable, python]
         name: run integration tests
-        entry: env PYTHON_37_ONLY=1 ./__tests__/test.sh
+        entry: env PYTHON_37_ONLY=1 NO_IT=1 ./__tests__/test.sh
         language: system
         verbose: true
         pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 A new `nav_repos` was added to the configuration. This is similar to the `repos` configuration except that `nav_repos`
 expects a `nav` to be present to use in the navigation. This configuration can also be used along with `!import` statements.
 
-### Usage Example
+#### Usage Example
 
 <details><summary><b>See example</b></summary>
 
@@ -59,7 +59,7 @@ In addition this release adds `keeps_docs_dir` to the `!import` statement, which
 
 A new `keep_docs_dir` was added to the `multirepo` config. Setting this to `true` will cause the plugin to not move the contents of the `docs_dir` up and delete it. See issue [#74](https://github.com/jdoiro3/mkdocs-multirepo-plugin/issues/74) for more details.
 
-### Usage Example
+#### Usage Example
 
 ```yaml
 plugins:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,52 @@
+## 0.6.0
+
+### Prs in Release
+
+- [Add support for nav repos](https://github.com/jdoiro3/mkdocs-multirepo-plugin/pull/80)
+
+### Added Features
+
+A new `nav_repos` was added to the configuration. This is similar to the `repos` configuration except that `nav_repos`
+expects a `nav` to be present to use in the navigation. This configuration can also be used along with `!import` statements.
+
+### Usage Example
+
+<details><summary><b>See example</b></summary>
+
+  ```yaml
+  plugins:
+    - search
+    - multirepo:
+        # (optional) tells multirepo to cleanup the temporary directory after site is built.
+        cleanup: false
+        nav_repos:
+          - name: backstage
+            import_url: https://github.com/backstage/backstage
+            # forward slash is needed in '/README.md' so that only the README.md in the root
+            # directory is imported and not all README.md files.
+            imports: [
+              docs/publishing.md, docs/integrations/index.md, /README.md,
+              # asset files needed
+              docs/assets/*
+              ]
+          - name: fast-api
+            import_url: https://github.com/tiangolo/fastapi
+            imports: [docs/en/docs/index.md]
+
+  nav:
+    - Backstage:
+        - Home: backstage/README.md
+        - Integration: backstage/docs/integrations/index.md
+        - Publishing: backstage/docs/publishing.md
+    - FastAPI: fast-api/docs/en/docs/index.md
+    # you can still use the !import statement
+    - MkdocStrings: '!import https://github.com/mkdocstrings/mkdocstrings'
+  ```
+
+</details>
+
+In addition this release adds `keeps_docs_dir` to the `!import` statement, which means one imported repo can override the behavior set by the global configuration. See [Fix edit urls and add new `keep_docs_dir` config param](https://github.com/jdoiro3/mkdocs-multirepo-plugin/pull/75) for more details.
+
 ## 0.5.0
 
 ### PRs in Release
@@ -10,7 +59,7 @@
 
 A new `keep_docs_dir` was added to the `multirepo` config. Setting this to `true` will cause the plugin to not move the contents of the `docs_dir` up and delete it. See issue [#74](https://github.com/jdoiro3/mkdocs-multirepo-plugin/issues/74) for more details.
 
-#### Usage Example
+### Usage Example
 
 ```yaml
 plugins:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ plugins:
       keep_docs_dir: true
 ```
 
+You'll now have 3 ways of importing docs:
+
+- [plugins.multirepo.repos](#repos-config): Use this method of importing if you don't have a `nav` section in the importees `mkdocs.yml` and want Mkdocs to generate navigation based on the directory structures. If there's a `nav` this will be ignored.
+- [plugins.multirepo.nav_repos](#nav-repos-config): Use this method of importing if you do have a `nav` section in the importees `mkdocs.yml` and want to refer to imported docs in the `nav` the same way as docs in the importees repo. This can be used alongside `!import` statements.
+- [!import](#import-statement): Used to specify docs to import within the `nav`.
+
+## Import Statement
+
 The plugin introduces the *!import* statement in your config's *nav* section. You can now use the import statement to add a documentation section, where the docs are pulled from the source repo.
 
 <details><summary><b>!import Statement Sections</b></summary>
@@ -88,6 +96,7 @@ nav:
 > - *nav* takes precedence over *repos* (see below).
 > - *{path}* can also be a [glob](https://en.wikipedia.org/wiki/Glob_(programming)) (e.g., `docs/*`).
 
+## Repos Config
 
 If you'd prefer *MkDocs* to build the site nav based on the directory structure, you can define your other repos within the *plugins* section.
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ plugins:
 
 You'll now have 3 ways of importing docs:
 
-- [plugins.multirepo.repos](#repos-config): Use this method if you don't have a `nav` section in the imported `mkdocs.yml` and want Mkdocs to generate navigation based on the directory structure. If there's a `nav` this will be ignored.
-- [plugins.multirepo.nav_repos](#nav-repos-config): Use this if you have a `nav` section in the imported `mkdocs.yml` and want to refer to imported docs in the `nav` the same way as docs in the imported repo. This can be used alongside `!import` statements.
+- [plugins.multirepo.repos](#repos-config): Use this method if you don't have a `nav` section in the imported `mkdocs.yml` and want Mkdocs to generate navigation based on the directory structure. If there's a `nav` this configuration will be ignored since `nav` configuration takes precedence.
+- [plugins.multirepo.nav_repos](#nav-repos-config): Use this if you have a `nav` section in your `mkdocs.yml` and want to refer to imported docs in the `nav` the same way as other docs in the repo. This can be used alongside `!import` statements.
 - [!import](#import-statement): Used to specify docs to import to a section in the `nav`. The imported repo needs to have a `mkdocs.yml` file with a `nav` section as well.
 
 ## Import Statement

--- a/README.md
+++ b/README.md
@@ -140,20 +140,35 @@ plugins:
 plugins:
   - search
   - multirepo:
+      # (optional) tells multirepo to cleanup the temporary directory after site is built.
+      cleanup: false
       nav_repos:
         - name: backstage
           import_url: https://github.com/backstage/backstage
-          imports: [docs/publishing.md, docs/integrations/index.md, README.md]
+          # forward slash is needed in '/README.md' so that only the README.md in the root
+          # directory is imported and not all README.md files.
+          imports: [
+            docs/publishing.md, docs/integrations/index.md, /README.md,
+            # asset files needed
+            docs/assets/*
+            ]
         - name: fast-api
-          import_url: https://github.com/tiangolo/fastapi?docs_dir=docs/en/docs/*
+          import_url: https://github.com/tiangolo/fastapi
           imports: [docs/en/docs/index.md]
 
 nav:
-  - Backstage: backstage/README.md
-  - 'Backstage Integration': backstage/docs/integrations/index.md
-  - 'Backstage Publishing': backstage/docs/publishing.md
-  - FastAPI: fast-api/docs/en/docs/index.md=
+  - Backstage:
+      - Home: backstage/README.md
+      - Integration: backstage/docs/integrations/index.md
+      - Publishing: backstage/docs/publishing.md
+      - Conduct: backstage/CODE_OF_CONDUCT.md
+      - Adapters: backstage/ADOPTERS.md
+      - Security: backstage/SECURITY.md
+      - Contributing: backstage/CONTRIBUTING.md
+  - FastAPI: fast-api/docs/en/docs/index.md
 ```
+
+## Run
 
 Once you're done configuring, run either `mkdocs serve` or `mkdocs build`. This will `import` the docs into a temporary directory and build the site.
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,25 @@ plugins:
 
 ## Nav Repos Config
 
+```yaml
+plugins:
+  - search
+  - multirepo:
+      nav_repos:
+        - name: backstage
+          import_url: https://github.com/backstage/backstage
+          imports: [docs/publishing.md, docs/integrations/index.md, README.md]
+        - name: fast-api
+          import_url: https://github.com/tiangolo/fastapi?docs_dir=docs/en/docs/*
+          imports: [docs/en/docs/index.md]
+
+nav:
+  - Backstage: backstage/README.md
+  - 'Backstage Integration': backstage/docs/integrations/index.md
+  - 'Backstage Publishing': backstage/docs/publishing.md
+  - FastAPI: fast-api/docs/en/docs/index.md=
+```
+
 Once you're done configuring, run either `mkdocs serve` or `mkdocs build`. This will `import` the docs into a temporary directory and build the site.
 
 ![mkdocs-multirepo-plugin-demo](https://user-images.githubusercontent.com/57968347/183310333-07576062-d4e0-47d1-ac2c-9b682fea8b4e.gif)

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ plugins:
 
 You'll now have 3 ways of importing docs:
 
-- [plugins.multirepo.repos](#repos-config): Use this method of importing if you don't have a `nav` section in the importees `mkdocs.yml` and want Mkdocs to generate navigation based on the directory structures. If there's a `nav` this will be ignored.
-- [plugins.multirepo.nav_repos](#nav-repos-config): Use this method of importing if you do have a `nav` section in the importees `mkdocs.yml` and want to refer to imported docs in the `nav` the same way as docs in the importees repo. This can be used alongside `!import` statements.
-- [!import](#import-statement): Used to specify docs to import within the `nav`.
+- [plugins.multirepo.repos](#repos-config): Use this method if you don't have a `nav` section in the importees `mkdocs.yml` and want Mkdocs to generate navigation based on the directory structure. If there's a `nav` this will be ignored.
+- [plugins.multirepo.nav_repos](#nav-repos-config): Use this if you have a `nav` section in the importees `mkdocs.yml` and want to refer to imported docs in the `nav` the same way as docs in the importees repo. This can be used alongside `!import` statements.
+- [!import](#import-statement): Used to specify docs to import to a section in the `nav`. The imported repo needs to have a `mkdocs.yml` file with a `nav` section as well.
 
 ## Import Statement
 
@@ -110,6 +110,7 @@ plugins:
       # you must keep the docs directory in the path (e.g., docs/path/to/file.md).
       keep_docs_dir: true
       repos:
+          # There will be a navigation section with this section name
         - section: Backstage
           # you can define the edit uri path
           import_url: 'https://github.com/backstage/backstage?edit_uri=/blob/master/'
@@ -132,6 +133,8 @@ plugins:
           section_path: python # Put this under the python menu entry
           import_url: 'https://github.com/samuelcolvin/pydantic?branch=main'
 ```
+
+## Nav Repos Config
 
 Once you're done configuring, run either `mkdocs serve` or `mkdocs build`. This will `import` the docs into a temporary directory and build the site.
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ plugins:
 
 You'll now have 3 ways of importing docs:
 
-- [plugins.multirepo.repos](#repos-config): Use this method if you don't have a `nav` section in the importees `mkdocs.yml` and want Mkdocs to generate navigation based on the directory structure. If there's a `nav` this will be ignored.
-- [plugins.multirepo.nav_repos](#nav-repos-config): Use this if you have a `nav` section in the importees `mkdocs.yml` and want to refer to imported docs in the `nav` the same way as docs in the importees repo. This can be used alongside `!import` statements.
+- [plugins.multirepo.repos](#repos-config): Use this method if you don't have a `nav` section in the imported `mkdocs.yml` and want Mkdocs to generate navigation based on the directory structure. If there's a `nav` this will be ignored.
+- [plugins.multirepo.nav_repos](#nav-repos-config): Use this if you have a `nav` section in the imported `mkdocs.yml` and want to refer to imported docs in the `nav` the same way as docs in the imported repo. This can be used alongside `!import` statements.
 - [!import](#import-statement): Used to specify docs to import to a section in the `nav`. The imported repo needs to have a `mkdocs.yml` file with a `nav` section as well.
 
 ## Import Statement

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ nav:
       - Security: backstage/SECURITY.md
       - Contributing: backstage/CONTRIBUTING.md
   - FastAPI: fast-api/docs/en/docs/index.md
+  # you can still use the !import statement
+  - MkdocStrings: '!import https://github.com/mkdocstrings/mkdocstrings'
 ```
 
 ## Run

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ plugins:
       # (optional) tells multirepo to cleanup the temporary directory after site is built.
       cleanup: true
       # if set the docs directory will not be removed when importing docs.
-      # When using this with a nav section in an imported repo you must keep the 
+      # When using this with a nav section in an imported repo you must keep the
       # docs directory in the path (e.g., docs/path/to/file.md).
       keep_docs_dir: true
 ```
@@ -100,7 +100,7 @@ plugins:
   - multirepo:
       # (optional) tells multirepo to cleanup the temporary directory after site is built.
       cleanup: true
-      # if set the docs directory will not be removed when importing docs. When using this with a nav section in an imported repo 
+      # if set the docs directory will not be removed when importing docs. When using this with a nav section in an imported repo
       # you must keep the docs directory in the path (e.g., docs/path/to/file.md).
       keep_docs_dir: true
       repos:
@@ -201,7 +201,7 @@ For `mkdocs serve` to work properly in an imported repo (a repo that is imported
 
 > Notes:
 > - You will also need to have `plugins` and `packages` the parent repo uses installed within your local `venv`.
-> - See documentation on the [set](https://git-scm.com/docs/git-sparse-checkout#Documentation/git-sparse-checkout.txt-emsetem) git command for `sparse-checkout` if you are confused with what `dirs` can contain.
+> - See documentation on the [set](https://git-scm.com/docs/git-sparse-checkout#Documentation/git-sparse-checkout.txt-emsetem) git command for `sparse-checkout` if you are confused with what `paths` can contain.
 
 ```yml
 plugins:
@@ -209,10 +209,10 @@ plugins:
     imported_repo: true
     url: https://github.com/squidfunk/mkdocs-material
     section_name: Backstage
-    # directories and files needed for building the site
+    # dirs/files needed for building the site
     # any path in docs will be included. For example, index.md is the
     # homepage of the parent site
-    dirs: ["material/*", "mkdocs.yml", "docs/index.md"]
+    paths: ["material/*", "mkdocs.yml", "docs/index.md"]
     custom_dir: material
     yml_file: mkdocs.yml # this can also be a relative path
     branch: master

--- a/README.md
+++ b/README.md
@@ -91,9 +91,6 @@ nav:
 
 If you'd prefer *MkDocs* to build the site nav based on the directory structure, you can define your other repos within the *plugins* section.
 
-> Note:
-> Cleanup should be set to `false` when developing (i.e., when calling `mkdocs serve`). This will prevent importing repos multiple times with livereload.
-
 ```yaml
 plugins:
   - search

--- a/__tests__/fixtures/parent-with-nav-repos/docs/index.md
+++ b/__tests__/fixtures/parent-with-nav-repos/docs/index.md
@@ -1,0 +1,3 @@
+# Hello World
+
+Main page of parent repo.

--- a/__tests__/fixtures/parent-with-nav-repos/mkdocs.yml
+++ b/__tests__/fixtures/parent-with-nav-repos/mkdocs.yml
@@ -1,0 +1,29 @@
+site_name: Test
+
+plugins:
+  - multirepo:
+      nav_repos:
+        - name: repo1
+          import_url: https://github.com/jdoiro3/mkdocs-multirepo-demoRepo1?branch=main
+          imports: [
+            docs/page1.md,
+            docs/page2.md,
+            /README.md,
+            ]
+        - name: repo2
+          import_url: https://github.com/jdoiro3/mkdocs-multirepo-demoRepo1?branch=ok-no-nav
+          imports: [
+            /README.md,
+            docs/index.md,
+            ]
+
+nav:
+  - Home: docs/index.md
+  - Repo1:
+      - Home: repo1/README.md
+      - Page1: repo1/docs/page1.md
+      - Page2: repo1/docs/page2.md
+  - Repo2:
+      - Home: repo2/README.md
+      - Index: repo2/docs/index.md
+  - Repo3: '!import https://github.com/jdoiro3/mkdocs-multirepo-demoRepo1?branch=ok-nav-simple'

--- a/__tests__/setup-bats.sh
+++ b/__tests__/setup-bats.sh
@@ -4,3 +4,4 @@ sudo add-apt-repository ppa:duggan/bats
 sudo apt-get update
 sudo apt-get install bats
 sudo apt-get install git
+sudo apt-get install tree

--- a/__tests__/test.bats
+++ b/__tests__/test.bats
@@ -159,19 +159,32 @@ teardown() {
   run mkdocs build --config-file=$parent/mkdocs.yml
   debugger
   # testing subsection import
+  assertFileExists "$parent/site/section/ok-nav-simple/index.html"
   run cat "$parent/site/section/ok-nav-simple/index.html"
   outputContains "Welcome to a simple repo."
+
+  assertFileExists "$parent/site/section/ok-nav-complex/index.html"
   run cat "$parent/site/section/ok-nav-complex/index.html"
   outputContains "Welcome to a complex repo."
+
+  assertFileExists "$parent/site/section/ok-nav-complex/section1/getting-started/index.html"
   run cat "$parent/site/section/ok-nav-complex/section1/getting-started/index.html"
   outputContains "Let's get started with section 1."
+
+  assertFileExists "$parent/site/section/ok-nav-complex/section2/getting-started/index.html"
   run cat "$parent/site/section/ok-nav-complex/section2/getting-started/index.html"
   outputContains "Let's get started with section 2."
+
+  assertFileExists "$parent/site/section/ok-nav-complex/section1/index.html"
   run cat "$parent/site/section/ok-nav-complex/section1/index.html"
   outputContains "Welcome to section 1."
+
+  assertFileExists "$parent/site/section/ok-nav-complex/section2/index.html"
   run cat "$parent/site/section/ok-nav-complex/section2/index.html"
   outputContains "Welcome to section 2."
+
   # testing an import within multiple subsections
+  assertFileExists "$parent/site/deepimport/subsection/subsection/ok-nav-simple/index.html"
   run cat "$parent/site/deepimport/subsection/subsection/ok-nav-simple/index.html"
   outputContains "Welcome to a simple repo."
 }
@@ -190,4 +203,39 @@ teardown() {
   run mkdocs build --config-file=$parent/mkdocs.yml
   debugger
   assertFileExists "$parent/site/ok-with-images/assets/images/zelda-dark-world.png"
+}
+
+@test "Build a mkdocs site with nav_repos" {
+  cd ${fixturesDir}
+  parent="parent-with-nav-repos"
+  run mkdocs build --config-file=$parent/mkdocs.yml
+
+  debugger
+  assertFileExists "$parent/site/index.html"
+  run cat "$parent/site/index.html"
+  outputContains "Main page of parent repo."
+
+  assertFileExists "$parent/site/repo1/index.html"
+  run cat "$parent/site/repo1/index.html"
+  outputContains "Used to demo the"
+
+  assertFileExists "$parent/site/repo1/docs/page1/index.html"
+  run cat "$parent/site/repo1/docs/page1/index.html"
+  outputContains "Welcome to Page1"
+
+  assertFileExists "$parent/site/repo1/docs/page2/index.html"
+  run cat "$parent/site/repo1/docs/page2/index.html"
+  outputContains "Welcome to Page2"
+
+  assertFileExists "$parent/site/repo2/index.html"
+  run cat "$parent/site/repo2/index.html"
+  outputContains "Used to demo the"
+
+  assertFileExists "$parent/site/repo2/index.html"
+  run cat "$parent/site/repo2/index.html"
+  outputContains "Used to demo the"
+
+  assertFileExists "$parent/site/repo3/index.html"
+  run cat "$parent/site/repo3/index.html"
+  outputContains "Welcome to a simple repo."
 }

--- a/__tests__/test.sh
+++ b/__tests__/test.sh
@@ -29,7 +29,11 @@ docker build -t mkdocs-multirepo-test-runner:$1 --quiet -f- . <<EOF
 EOF
 
 printf "\nRunning E2E tests via Bats in Docker (python:$1) -------->\n"
-docker run -it -w /workspace -v $(pwd):/workspace mkdocs-multirepo-test-runner:$1
+if [[ ! -z "$IT" ]]; then
+  docker run -it -w /workspace -v $(pwd):/workspace mkdocs-multirepo-test-runner:$1
+else
+  docker run -w /workspace -v $(pwd):/workspace mkdocs-multirepo-test-runner:$1
+fi
 }
 
 if [[ ! -z "$PYTHON_37_ONLY" ]]; then

--- a/__tests__/test.sh
+++ b/__tests__/test.sh
@@ -20,7 +20,7 @@ docker build -t mkdocs-multirepo-test-runner:$1 --quiet -f- . <<EOF
   COPY ./mkdocs_multirepo_plugin /workspace/mkdocs_multirepo_plugin
   COPY ./README.md /workspace/README.md
   COPY ./integration-requirements.txt /workspace/integration-requirements.txt
-  RUN apt-get -y update && apt-get -yyy install bats && apt-get -yyy install git
+  RUN apt-get -y update && apt-get -yyy install bats && apt-get -yyy install git && apt-get install tree
   RUN pip install --upgrade pip
   RUN pip install -r ./workspace/integration-requirements.txt
   RUN pip install ./workspace

--- a/__tests__/test.sh
+++ b/__tests__/test.sh
@@ -29,10 +29,10 @@ docker build -t mkdocs-multirepo-test-runner:$1 --quiet -f- . <<EOF
 EOF
 
 printf "\nRunning E2E tests via Bats in Docker (python:$1) -------->\n"
-if [[ ! -z "$IT" ]]; then
-  docker run -it -w /workspace -v $(pwd):/workspace mkdocs-multirepo-test-runner:$1
-else
+if [[ ! -z "$NO_IT" ]]; then
   docker run -w /workspace -v $(pwd):/workspace mkdocs-multirepo-test-runner:$1
+else
+  docker run -it -w /workspace -v $(pwd):/workspace mkdocs-multirepo-test-runner:$1
 fi
 }
 

--- a/mkdocs_multirepo_plugin/plugin.py
+++ b/mkdocs_multirepo_plugin/plugin.py
@@ -212,9 +212,9 @@ class MultirepoPlugin(BasePlugin):
                 raise ImportSyntaxError(
                     "import_url should only contain the url with plugin accepted params. You included '!import'."
                 )
-            name_slug = slugify(repo.section)
+            section_slug = slugify(repo.section)
             path = repo.section_path
-            repo_name = f"{path}/{name_slug}" if path is not None else name_slug
+            repo_name = f"{path}/{section_slug}" if path is not None else section_slug
             # mkdocs config values edit_uri and repo_url aren't set
             if need_to_derive_edit_uris:
                 derived_edit_uri = self.derive_config_edit_uri(
@@ -246,13 +246,14 @@ class MultirepoPlugin(BasePlugin):
         docs_repo_objs: List[DocsRepo] = []
         for nr in nav_repos:
             import_stmt = parse_repo_url(nr.import_url)
+            name: str = slugify(nr.name)
             # mkdocs config values edit_uri and repo_url aren't set
             if need_to_derive_edit_uris:
                 derived_edit_uri = self.derive_config_edit_uri(
-                    nr.name, import_stmt.get("url"), config
+                    name, import_stmt.get("url"), config
                 )
             repo: DocsRepo = DocsRepo(
-                name=nr.name,
+                name=name,
                 url=import_stmt.get("url"),
                 temp_dir=self.temp_dir,
                 branch=import_stmt.get("branch", DEFAULT_BRANCH),

--- a/mkdocs_multirepo_plugin/plugin.py
+++ b/mkdocs_multirepo_plugin/plugin.py
@@ -14,10 +14,7 @@ from slugify import slugify
 
 from .structure import (
     DocsRepo,
-    MultirepoConfig,
-    NavRepoConfig,
     Repo,
-    RepoConfig,
     batch_execute,
     batch_import,
     get_files,

--- a/mkdocs_multirepo_plugin/plugin.py
+++ b/mkdocs_multirepo_plugin/plugin.py
@@ -306,9 +306,8 @@ class MultirepoPlugin(BasePlugin):
             log.info("Multirepo plugin importing docs...")
             # nav takes precedence over repos
             if nav:
-                if not nav_repos:
-                    return self.handle_nav_import(config)
-                else:
+                config = self.handle_nav_import(config)
+                if nav_repos:
                     return self.handle_nav_repos_import(config, nav_repos)
             # navigation isn't defined but plugin section has repos
             return self.handle_repos_import(config, repos)

--- a/mkdocs_multirepo_plugin/plugin.py
+++ b/mkdocs_multirepo_plugin/plugin.py
@@ -298,7 +298,7 @@ class MultirepoPlugin(BasePlugin):
                 return config
             if nav and repos:
                 log.warning(
-                    "Multirepo plugin is ignoring multirepo repos. Nav takes precedence."
+                    "Multirepo plugin is ignoring plugins.multirepo.repos. Nav takes precedence."
                 )
             if not nav and nav_repos:
                 log.warning(
@@ -310,6 +310,7 @@ class MultirepoPlugin(BasePlugin):
                 config = self.handle_nav_import(config)
                 if nav_repos:
                     return self.handle_nav_repos_import(config, nav_repos)
+                return config
             # navigation isn't defined but plugin section has repos
             return self.handle_repos_import(config, repos)
 

--- a/mkdocs_multirepo_plugin/plugin.py
+++ b/mkdocs_multirepo_plugin/plugin.py
@@ -35,20 +35,6 @@ if is_windows():
 
 IMPORT_STATEMENT = "!import"
 DEFAULT_BRANCH = "master"
-REPO_CONFIG_KEYS: Set[str] = {"import_url", "section", "section_path"}
-NAV_REPO_CONFIG_KEYS: Set[str] = {"name", "url", "import"}
-
-
-def validate_repo_config(import_stmt: Dict[str, str], repo: Dict[str, str]) -> None:
-    if "!import" in import_stmt.get("url"):
-        raise ImportSyntaxError(
-            "import_url should only contain the url with plugin accepted params. You included '!import'."
-        )
-    if set(repo.keys()).difference(REPO_CONFIG_KEYS) != set():
-        raise ReposSectionException(
-            f"Repos section now only supports {REPO_CONFIG_KEYS}."
-            "All other config values should use the nav import url config (i.e., [url]?[key]=[value])"
-        )
 
 
 class ReposSectionException(Exception):
@@ -196,7 +182,10 @@ class MultirepoPlugin(BasePlugin):
         docs_repo_objs: List[DocsRepo] = []
         for repo in repos:
             import_stmt = parse_repo_url(repo.import_url)
-            validate_repo_config(import_stmt=import_stmt, repo=repo)
+            if "!import" in import_stmt.get("url"):
+                raise ImportSyntaxError(
+                    "import_url should only contain the url with plugin accepted params. You included '!import'."
+                )
             name_slug = slugify(repo.section)
             path = repo.section_path
             repo_name = f"{path}/{name_slug}" if path is not None else name_slug

--- a/mkdocs_multirepo_plugin/plugin.py
+++ b/mkdocs_multirepo_plugin/plugin.py
@@ -1,6 +1,7 @@
 import shutil
 import tempfile
 from copy import deepcopy
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
@@ -39,6 +40,36 @@ DEFAULT_BRANCH = "master"
 
 class ReposConfigException(Exception):
     pass
+
+
+@dataclass
+class RepoConfig:
+    section: str
+    import_url: str
+    section_path: Optional[str] = None
+
+
+@dataclass
+class NavRepoConfig:
+    name: str
+    import_url: str
+    imports: List[str] = field(default_factory=list)
+
+
+@dataclass
+class MultirepoConfig:
+    cleanup: bool
+    repos: List[RepoConfig]
+    nav_repos: List[NavRepoConfig]
+    imported_repo: bool
+    temp_dir: str
+    keep_docs_dir: bool
+    section_name: str
+    url: Optional[str] = None
+    dirs: Optional[List[str]] = None
+    custom_dir: Optional[str] = None
+    yml_file: Optional[str] = None
+    branch: Optional[str] = None
 
 
 class MultirepoPlugin(BasePlugin):

--- a/mkdocs_multirepo_plugin/plugin.py
+++ b/mkdocs_multirepo_plugin/plugin.py
@@ -232,6 +232,7 @@ class MultirepoPlugin(BasePlugin):
                     or derived_edit_uri,
                     multi_docs=bool(import_stmt.get("multi_docs", False)),
                     extra_imports=import_stmt.get("extra_imports", []),
+                    keep_docs_dir=import_stmt.get("keep_docs_dir", False),
                 )
             )
         asyncio_run(batch_import(docs_repo_objs))

--- a/mkdocs_multirepo_plugin/plugin.py
+++ b/mkdocs_multirepo_plugin/plugin.py
@@ -3,7 +3,7 @@ import tempfile
 from copy import deepcopy
 from dataclasses import _MISSING_TYPE, dataclass, field, fields
 from pathlib import Path
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional
 
 import dacite as dc
 from mkdocs.config import Config, config_options
@@ -11,7 +11,7 @@ from mkdocs.plugins import BasePlugin
 from mkdocs.structure.files import File, Files
 from mkdocs.theme import Theme
 from slugify import slugify
-from typing_inspect import get_origin, is_literal_type
+from typing_inspect import get_origin
 
 from .structure import (
     DocsRepo,

--- a/mkdocs_multirepo_plugin/plugin.py
+++ b/mkdocs_multirepo_plugin/plugin.py
@@ -261,6 +261,8 @@ class MultirepoPlugin(BasePlugin):
                 or config.get("edit_uri")
                 or derived_edit_uri,
             )
+            if repo.cloned:
+                repo.delete_repo()
             docs_repo_objs.append(repo)
             self.repos[repo.name] = repo
         asyncio_run(batch_execute(repos=docs_repo_objs, method=Repo.sparse_clone))

--- a/mkdocs_multirepo_plugin/scripts/sparse_clone.sh
+++ b/mkdocs_multirepo_plugin/scripts/sparse_clone.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 url="$1"
-docs_dir="$2"
+name="$2"
 branch=$3
 shift 3
 dirs=( "$@" )
@@ -18,7 +18,7 @@ else
   url_to_use="$url"
 fi
 
-git clone --branch "$branch" --depth 1 --filter=blob:none --sparse $url_to_use "$docs_dir" || exit 1
-cd "$docs_dir"
+git clone --branch "$branch" --depth 1 --filter=blob:none --sparse $url_to_use "$name" || exit 1
+cd "$name"
 git sparse-checkout set --no-cone ${dirs[*]}
 rm -rf .git

--- a/mkdocs_multirepo_plugin/structure.py
+++ b/mkdocs_multirepo_plugin/structure.py
@@ -149,6 +149,7 @@ def get_import_stmts(
                 multi_docs=bool(import_stmt.get("multi_docs", False)),
                 config=import_stmt.get("config", "mkdocs.yml"),
                 extra_imports=import_stmt.get("extra_imports", []),
+                keep_docs_dir=import_stmt.get("keep_docs_dir", False),
             )
             imports.append(NavImport(section, nav[index], repo))
             path_to_section.pop()
@@ -264,6 +265,7 @@ class DocsRepo(Repo):
         multi_docs: bool = False,
         config: str = "mkdocs.yml",
         extra_imports: List[str] = None,
+        keep_docs_dir: bool = False,
         *args,
         **kwargs,
     ):
@@ -276,6 +278,7 @@ class DocsRepo(Repo):
         self.config = config
         self.extra_imports = extra_imports
         self.edit_uri = self._fix_edit_uri(edit_uri)
+        self.keep_docs_dir = keep_docs_dir
 
     def __str__(self):
         return f"DocsRepo({self.name}, {self.url}, {self.location})"
@@ -373,7 +376,7 @@ class DocsRepo(Repo):
             self.transform_docs_dir()
         else:
             await self.sparse_clone([self.docs_dir, self.config] + self.extra_imports)
-            if not keep_docs_dir:
+            if not (self.keep_docs_dir and (self.keep_docs_dir or keep_docs_dir)):
                 await execute_bash_script(
                     "mv_docs_up.sh",
                     [self.docs_dir.replace("/*", "")],

--- a/mkdocs_multirepo_plugin/structure.py
+++ b/mkdocs_multirepo_plugin/structure.py
@@ -195,12 +195,10 @@ class Repo:
         paths = paths or self.paths
         args = [self.url, self.name, self.branch] + paths
         if git_supports_sparse_clone():
-            stdout = await execute_bash_script("sparse_clone.sh", args, self.temp_dir)
+            await execute_bash_script("sparse_clone.sh", args, self.temp_dir)
         else:
-            stdout = await execute_bash_script(
-                "sparse_clone_old.sh", args, self.temp_dir
-            )
-        return stdout
+            await execute_bash_script("sparse_clone_old.sh", args, self.temp_dir)
+        return self
 
     def delete_repo(self) -> None:
         """Deletes the repo from the temp directory"""
@@ -265,10 +263,12 @@ class DocsRepo(Repo):
         multi_docs: bool = False,
         config: str = "mkdocs.yml",
         extra_imports: List[str] = None,
+        *args,
+        **kwargs,
     ):
         if extra_imports is None:
             extra_imports = []
-        super().__init__(name, url, branch, temp_dir)
+        super().__init__(name, url, branch, temp_dir, *args, **kwargs)
         self.docs_dir = docs_dir
         self.multi_docs = multi_docs
         self.src_path_map = {}

--- a/mkdocs_multirepo_plugin/structure.py
+++ b/mkdocs_multirepo_plugin/structure.py
@@ -362,8 +362,8 @@ class DocsRepo(Repo):
         self, remove_existing: bool = True, keep_docs_dir: bool = False
     ) -> "DocsRepo":
         """imports the markdown documentation to be included in the site asynchronously"""
-        if self.location.is_dir() and remove_existing:
-            shutil.rmtree(str(self.location))
+        if self.cloned and remove_existing:
+            self.delete_repo()
         if self.multi_docs:
             if self.docs_dir == "docs/*":
                 docs_dir = "docs"

--- a/mkdocs_multirepo_plugin/structure.py
+++ b/mkdocs_multirepo_plugin/structure.py
@@ -131,11 +131,11 @@ def get_import_stmts(
             continue
         ((section, value),) = entry.items()
         path_to_section.append(section)
-        if type(value) is list:
+        if isinstance(value, list):
             imports += get_import_stmts(
                 value, temp_dir, default_branch, path_to_section
             )
-        elif value.startswith("!import"):
+        elif isinstance(value, str) and value.startswith("!import"):
             import_stmt: Dict[str, str] = parse_import(value)
             # slugify the section names and turn them into a valid path string
             path = str(Path(*[slugify(section) for section in path_to_section]))
@@ -152,13 +152,7 @@ def get_import_stmts(
                 keep_docs_dir=import_stmt.get("keep_docs_dir", False),
             )
             imports.append(NavImport(section, nav[index], repo))
-            path_to_section.pop()
-        else:
-            path_to_section.pop()
-    try:
         path_to_section.pop()
-    except IndexError:
-        pass
     return imports
 
 

--- a/mkdocs_multirepo_plugin/structure.py
+++ b/mkdocs_multirepo_plugin/structure.py
@@ -39,10 +39,18 @@ class NavRepoConfig:
 
 @dataclass
 class MultirepoConfig:
+    cleanup: bool
     repos: List[RepoConfig]
     nav_repos: List[NavRepoConfig]
     imported_repo: bool
     temp_dir: str
+    keep_docs_dir: bool
+    section_name: str
+    url: Optional[str] = None
+    dirs: Optional[List[str]] = None
+    custom_dir: Optional[str] = None
+    yml_file: Optional[str] = None
+    branch: Optional[str] = None
 
 
 def is_yaml_file(file: File) -> bool:

--- a/mkdocs_multirepo_plugin/structure.py
+++ b/mkdocs_multirepo_plugin/structure.py
@@ -3,7 +3,6 @@ import asyncio
 import os
 import shutil
 import time
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
@@ -21,36 +20,6 @@ from .util import (
     log,
     remove_parents,
 )
-
-
-@dataclass
-class RepoConfig:
-    section: str
-    import_url: str
-    section_path: Optional[str] = None
-
-
-@dataclass
-class NavRepoConfig:
-    name: str
-    import_url: str
-    imports: List[str] = field(default_factory=list)
-
-
-@dataclass
-class MultirepoConfig:
-    cleanup: bool
-    repos: List[RepoConfig]
-    nav_repos: List[NavRepoConfig]
-    imported_repo: bool
-    temp_dir: str
-    keep_docs_dir: bool
-    section_name: str
-    url: Optional[str] = None
-    dirs: Optional[List[str]] = None
-    custom_dir: Optional[str] = None
-    yml_file: Optional[str] = None
-    branch: Optional[str] = None
 
 
 def is_yaml_file(file: File) -> bool:

--- a/poetry.lock
+++ b/poetry.lock
@@ -229,6 +229,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
@@ -375,6 +383,18 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "typing-inspect"
+version = "0.8.0"
+description = "Runtime inspection utilities for typing module."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+mypy-extensions = ">=0.3.0"
+typing-extensions = ">=3.7.4"
+
+[[package]]
 name = "urllib3"
 version = "1.22"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -412,7 +432,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (
 [metadata]
 lock-version = "1.1"
 python-versions = "*"
-content-hash = "3bdaa4a682d3ba6ec1f24d4511b7aeeea952327dcd162dc395add42f0a724537"
+content-hash = "2e43473170750c01694327ffaa13aa4b20c236f9333d8d7c78c56da4030ec499"
 
 [metadata.files]
 aiofiles = [
@@ -564,6 +584,10 @@ mkdocs-material-extensions = [
     {file = "mkdocs-material-extensions-1.0.3.tar.gz", hash = "sha256:bfd24dfdef7b41c312ede42648f9eb83476ea168ec163b613f9abd12bbfddba2"},
     {file = "mkdocs_material_extensions-1.0.3-py3-none-any.whl", hash = "sha256:a82b70e533ce060b2a5d9eb2bc2e1be201cf61f901f93704b4acf6e3d5983a44"},
 ]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
@@ -657,6 +681,10 @@ text-unidecode = [
 typing-extensions = [
     {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
     {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
+]
+typing-inspect = [
+    {file = "typing_inspect-0.8.0-py3-none-any.whl", hash = "sha256:5fbf9c1e65d4fa01e701fe12a5bca6c6e08a4ffd5bc60bfac028253a447c5188"},
+    {file = "typing_inspect-0.8.0.tar.gz", hash = "sha256:8b1ff0c400943b6145df8119c41c244ca8207f1f10c9c057aeed1560e4806e3d"},
 ]
 urllib3 = [
     {file = "urllib3-1.22-py2.py3-none-any.whl", hash = "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -54,6 +54,28 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "dacite"
+version = "1.8.0"
+description = "Simple creation of data classes from dictionaries."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+dataclasses = {version = "*", markers = "python_version < \"3.7\""}
+
+[package.extras]
+dev = ["black", "coveralls", "mypy", "pre-commit", "pylint", "pytest (>=5)", "pytest-benchmark", "pytest-cov"]
+
+[[package]]
+name = "dataclasses"
+version = "0.8"
+description = "A backport of the dataclasses module for Python 3.6"
+category = "main"
+optional = false
+python-versions = ">=3.6, <3.7"
+
+[[package]]
 name = "flake8"
 version = "3.9.2"
 description = "the modular source code checker: pep8 pyflakes and co"
@@ -390,7 +412,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (
 [metadata]
 lock-version = "1.1"
 python-versions = "*"
-content-hash = "43a3b8b8c1da2a5e08a9eaf34efea99e7d629a7732c9bd4939f35f4754053313"
+content-hash = "3bdaa4a682d3ba6ec1f24d4511b7aeeea952327dcd162dc395add42f0a724537"
 
 [metadata.files]
 aiofiles = [
@@ -418,6 +440,14 @@ click = [
 colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+]
+dacite = [
+    {file = "dacite-1.8.0-py3-none-any.whl", hash = "sha256:f7b1205cc5d9b62835aac8cbc1e6e37c1da862359a401f1edbe2ae08fbdc6193"},
+    {file = "dacite-1.8.0.tar.gz", hash = "sha256:6257a5e505b61a8cafee7ef3ad08cf32ee9b885718f42395d017e0a9b4c6af65"},
+]
+dataclasses = [
+    {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
+    {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
 ]
 flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mkdocs-multirepo-plugin"
-version = "0.5.0"
+version = "0.6.0"
 description = "Build documentation in multiple repos into one site."
 authors = ["jdoiro3 <josephdoiron1234@yahoo.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ mkdocs = {version = ">=1.0.4", python = ">=3.6"}
 asyncio = "*"
 python-slugify = {version = "*", python = ">=2.7,<2.8 || >=3.6.0"}
 dacite = {version = "^1.8.0", python = ">=3.6"}
+typing-inspect = {version = "^0.8.0", python = ">=3.6"}
 
 [tool.poetry.dev-dependencies]
 aiofiles = {version = "*", python = ">=3.6,<4.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ mv_docs_up = { reference = 'mkdocs_multirepo_plugin/scripts/mv_docs_up.sh', type
 mkdocs = {version = ">=1.0.4", python = ">=3.6"}
 asyncio = "*"
 python-slugify = {version = "*", python = ">=2.7,<2.8 || >=3.6.0"}
+dacite = {version = "^1.8.0", python = ">=3.6"}
 
 [tool.poetry.dev-dependencies]
 aiofiles = {version = "*", python = ">=3.6,<4.0"}


### PR DESCRIPTION
New feature details in https://github.com/jdoiro3/mkdocs-multirepo-plugin/issues/11

This PR adds the support for `nav_repos`. See example below.

```yaml
plugins:
  - search
  - multirepo:
      # (optional) tells multirepo to cleanup the temporary directory after site is built.
      cleanup: false
      nav_repos:
        - name: backstage
          import_url: https://github.com/backstage/backstage
          # forward slash is needed in '/README.md' so that only the README.md in the root
          # directory is imported and not all README.md files.
          imports: [
            docs/publishing.md, docs/integrations/index.md, /README.md,
            # asset files needed
            docs/assets/*
            ]
        - name: fast-api
          import_url: https://github.com/tiangolo/fastapi
          imports: [docs/en/docs/index.md]

nav:
  - Backstage:
      - Home: backstage/README.md
      - Integration: backstage/docs/integrations/index.md
      - Publishing: backstage/docs/publishing.md
  - FastAPI: fast-api/docs/en/docs/index.md
  # you can still use the !import statement
  - MkdocStrings: '!import https://github.com/mkdocstrings/mkdocstrings'
 ```

In addition to the new `nav_repos` config, this PR adds support for a `!import` statement to include `keep_docs_dir`. If set to `true` the docs directory will not be removed from the directory tree.

## TODO

- [x] update docs
- [x] write tests
- [ ] see if I can consolidate/simplify configuration for users.