### PR TITLE
Fix asyncio and urllib3 dependencies to support python 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.2
+
+### Prs in Release
+
+- [Fix deps for Python 3.10](https://github.com/jdoiro3/mkdocs-multirepo-plugin/pull/104)
+
 ## 0.6.1
 
 ### Prs in Release

--- a/poetry.lock
+++ b/poetry.lock
@@ -664,18 +664,19 @@ typing-extensions = ">=3.7.4"
 
 [[package]]
 name = "urllib3"
-version = "1.22"
+version = "1.26.16"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
-    {file = "urllib3-1.22-py2.py3-none-any.whl", hash = "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b"},
-    {file = "urllib3-1.22.tar.gz", hash = "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"},
+    {file = "urllib3-1.26.16-py2.py3-none-any.whl", hash = "sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f"},
+    {file = "urllib3-1.26.16.tar.gz", hash = "sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14"},
 ]
 
 [package.extras]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
@@ -735,4 +736,4 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (
 [metadata]
 lock-version = "2.0"
 python-versions = "*"
-content-hash = "8690e351e8abc3a4ed396e8fd55f0d63e0c9a62ce6ea34dc68b8a3e90accef7e"
+content-hash = "1887856014f060ee34c89686e8d501ae2b71ff08388a294f777dd793d97991fc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mkdocs-multirepo-plugin"
-version = "0.6.1"
+version = "0.6.2"
 description = "Build documentation in multiple repos into one site."
 authors = ["jdoiro3 <josephdoiron1234@yahoo.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ mv_docs_up = { reference = 'mkdocs_multirepo_plugin/scripts/mv_docs_up.sh', type
 
 [tool.poetry.dependencies]
 mkdocs = {version = ">=1.0.4", python = ">=3.6"}
-asyncio = "*"
+asyncio = {version = "*", python = "<=3.8"}
 python-slugify = {version = "*", python = ">=2.7,<2.8 || >=3.6.0"}
 dacite = {version = "^1.8.0", python = ">=3.6"}
 typing-inspect = {version = "^0.8.0", python = ">=3.6"}


### PR DESCRIPTION
1. asyncio is not needed on modern python (say > 3.8). Moreover, it breaks virtualenv when poetry 1.5.1 installs it on python 3.10. Stacktrace: 

```
❯ pip list
Traceback (most recent call last):
  File "/Users/me/Projects/ND/docs/.venv/bin/pip", line 5, in <module>
    from pip._internal.cli.main import main
  File "/Users/me/Projects/ND/docs/.venv/lib/python3.10/site-packages/pip/_internal/cli/main.py", line 9, in <module>
    from pip._internal.cli.autocompletion import autocomplete
  File "/Users/me/Projects/ND/docs/.venv/lib/python3.10/site-packages/pip/_internal/cli/autocompletion.py", line 10, in <module>
    from pip._internal.cli.main_parser import create_main_parser
  File "/Users/me/Projects/ND/docs/.venv/lib/python3.10/site-packages/pip/_internal/cli/main_parser.py", line 8, in <module>
    from pip._internal.cli import cmdoptions
  File "/Users/me/Projects/ND/docs/.venv/lib/python3.10/site-packages/pip/_internal/cli/cmdoptions.py", line 24, in <module>
    from pip._internal.cli.parser import ConfigOptionParser
  File "/Users/me/Projects/ND/docs/.venv/lib/python3.10/site-packages/pip/_internal/cli/parser.py", line 12, in <module>
    from pip._internal.configuration import Configuration, ConfigurationError
  File "/Users/me/Projects/ND/docs/.venv/lib/python3.10/site-packages/pip/_internal/configuration.py", line 26, in <module>
    from pip._internal.utils.logging import getLogger
  File "/Users/me/Projects/ND/docs/.venv/lib/python3.10/site-packages/pip/_internal/utils/logging.py", line 29, in <module>
    from pip._internal.utils.misc import ensure_dir
  File "/Users/me/Projects/ND/docs/.venv/lib/python3.10/site-packages/pip/_internal/utils/misc.py", line 38, in <module>
    from pip._vendor.tenacity import retry, stop_after_delay, wait_fixed
  File "/Users/me/Projects/ND/docs/.venv/lib/python3.10/site-packages/pip/_vendor/tenacity/__init__.py", line 514, in <module>
    from pip._vendor.tenacity._asyncio import AsyncRetrying  # noqa:E402,I100
  File "/Users/me/Projects/ND/docs/.venv/lib/python3.10/site-packages/pip/_vendor/tenacity/_asyncio.py", line 21, in <module>
    from asyncio import sleep
  File "/Users/me/Projects/ND/docs/.venv/lib/python3.10/site-packages/asyncio/__init__.py", line 21, in <module>
    from .base_events import *
  File "/Users/me/Projects/ND/docs/.venv/lib/python3.10/site-packages/asyncio/base_events.py", line 296
    future = tasks.async(future, loop=self)
                   ^^^^^
SyntaxError: invalid syntax
```

2. urllib3 has been resolved to version 1.22 that knows nothing about python 3.10, so it doesn't work. I've updated it to 1.26.16 which seems ok. Before I've had the stacktrace:

```
❯ poetry show
Traceback (most recent call last):
  File "/Users/me/Projects/My/mkdocs-multirepo-plugin/.venv/lib/python3.10/site-packages/cleo/application.py", line 327, in run
    exit_code = self._run(io)
  File "/Users/me/Projects/My/mkdocs-multirepo-plugin/.venv/lib/python3.10/site-packages/poetry/console/application.py", line 188, in _run
    self._load_plugins(io)
  File "/Users/me/Projects/My/mkdocs-multirepo-plugin/.venv/lib/python3.10/site-packages/poetry/console/application.py", line 358, in _load_plugins
    manager.load_plugins()
  File "/Users/me/Projects/My/mkdocs-multirepo-plugin/.venv/lib/python3.10/site-packages/poetry/plugins/plugin_manager.py", line 38, in load_plugins
    self._load_plugin_entry_point(ep)
  File "/Users/me/Projects/My/mkdocs-multirepo-plugin/.venv/lib/python3.10/site-packages/poetry/plugins/plugin_manager.py", line 76, in _load_plugin_entry_point
    plugin = ep.load()  # type: ignore[no-untyped-call]
  File "/Users/me/.pyenv/versions/3.10.8/lib/python3.10/importlib/metadata/__init__.py", line 171, in load
    module = import_module(match.group('module'))
  File "/Users/me/.pyenv/versions/3.10.8/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/me/Projects/My/mkdocs-multirepo-plugin/.venv/lib/python3.10/site-packages/poetry_plugin_export/plugins.py", line 7, in <module>
    from poetry_plugin_export.command import ExportCommand
  File "/Users/me/Projects/My/mkdocs-multirepo-plugin/.venv/lib/python3.10/site-packages/poetry_plugin_export/command.py", line 10, in <module>
    from poetry_plugin_export.exporter import Exporter
  File "/Users/me/Projects/My/mkdocs-multirepo-plugin/.venv/lib/python3.10/site-packages/poetry_plugin_export/exporter.py", line 11, in <module>
    from poetry.repositories.http_repository import HTTPRepository
  File "/Users/me/Projects/My/mkdocs-multirepo-plugin/.venv/lib/python3.10/site-packages/poetry/repositories/http_repository.py", line 14, in <module>
    import requests
  File "/Users/me/Projects/My/mkdocs-multirepo-plugin/.venv/lib/python3.10/site-packages/requests/__init__.py", line 43, in <module>
    import urllib3
  File "/Users/me/Projects/My/mkdocs-multirepo-plugin/.venv/lib/python3.10/site-packages/urllib3/__init__.py", line 8, in <module>
    from .connectionpool import (
  File "/Users/me/Projects/My/mkdocs-multirepo-plugin/.venv/lib/python3.10/site-packages/urllib3/connectionpool.py", line 29, in <module>
    from .connection import (
  File "/Users/me/Projects/My/mkdocs-multirepo-plugin/.venv/lib/python3.10/site-packages/urllib3/connection.py", line 39, in <module>
    from .util.ssl_ import (
  File "/Users/me/Projects/My/mkdocs-multirepo-plugin/.venv/lib/python3.10/site-packages/urllib3/util/__init__.py", line 3, in <module>
    from .connection import is_connection_dropped
  File "/Users/me/Projects/My/mkdocs-multirepo-plugin/.venv/lib/python3.10/site-packages/urllib3/util/connection.py", line 3, in <module>
    from .wait import wait_for_read
  File "/Users/me/Projects/My/mkdocs-multirepo-plugin/.venv/lib/python3.10/site-packages/urllib3/util/wait.py", line 1, in <module>
    from .selectors import (
  File "/Users/me/Projects/My/mkdocs-multirepo-plugin/.venv/lib/python3.10/site-packages/urllib3/util/selectors.py", line 14, in <module>
    from collections import namedtuple, Mapping
ImportError: cannot import name 'Mapping' from 'collections' (/Users/me/.pyenv/versions/3.10.8/lib/python3.10/collections/__init__.py)
```