### PR TITLE
Only exclude mkdocs config YAML files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.3
+
+### Prs in Release
+
+- [Only exclude mkdocs config YAML files.](https://github.com/jdoiro3/mkdocs-multirepo-plugin/pull/117)
+
 ## 0.6.2
 
 ### Prs in Release

--- a/mkdocs_multirepo_plugin/plugin.py
+++ b/mkdocs_multirepo_plugin/plugin.py
@@ -321,8 +321,11 @@ class MultirepoPlugin(BasePlugin):
             repo_files: List[File]
             for repo in self.repos.values():
                 repo_files = get_files(config, repo)
+                repo_config_path = repo.config_path
                 for f in repo_files:
-                    if not is_yaml_file(f):
+                    if f.src_path == repo_config_path:
+                        log.info(f"Multirepo plugin is not copying config file: {f.src_path}")
+                    else:
                         # the file needs to know about the repo it belongs to
                         f.repo = repo
                         files.append(f)

--- a/mkdocs_multirepo_plugin/structure.py
+++ b/mkdocs_multirepo_plugin/structure.py
@@ -300,6 +300,10 @@ class DocsRepo(Repo):
     def name_length(self):
         return len(Path(self.name).parts)
 
+    @property
+    def config_path(self):
+        return os.path.join(self.name, self.config)
+
     def keep_docs_dir(self, global_keep_docs_dir: bool = False):
         if self._keep_docs_dir is None:
             return global_keep_docs_dir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mkdocs-multirepo-plugin"
-version = "0.6.2"
+version = "0.6.3"
 description = "Build documentation in multiple repos into one site."
 authors = ["jdoiro3 <josephdoiron1234@yahoo.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux"
 ]
 
+
 [tool.poetry.scripts]
 sparse_clone = { reference = 'mkdocs_multirepo_plugin/scripts/sparse_clone.sh', type = "file" }
 sparse_clone_old = { reference = 'mkdocs_multirepo_plugin/scripts/sparse_clone_old.sh', type = "file" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux"
 ]
 
-
 [tool.poetry.scripts]
 sparse_clone = { reference = 'mkdocs_multirepo_plugin/scripts/sparse_clone.sh', type = "file" }
 sparse_clone_old = { reference = 'mkdocs_multirepo_plugin/scripts/sparse_clone_old.sh', type = "file" }


### PR DESCRIPTION
There was a blanket exclusion of all YAML files introduced to fix issue #9. There are certain use-cases where non-mkdocs YAML files should be included in the documentation - e.g. OpenAPI spec files.

This change only excludes YAML files that are marked as mkdocs config file for the repo being imported.

This passes the existing test "Make sure imported repo's mkdocs.yml isn't in build output".

Fix for issue #107