### PR TITLE
support cloning gitlab's CI_JOB_TOKEN

### DIFF
--- a/mkdocs_multirepo_plugin/scripts/sparse_clone.sh
+++ b/mkdocs_multirepo_plugin/scripts/sparse_clone.sh
@@ -15,6 +15,8 @@ if [[ -n  "$AccessToken" ]]; then
     git config http.extraheader "AUTHORIZATION: bearer $AccessToken"
 elif [[ -n  "$GithubAccessToken" ]]; then
     url_to_use="${protocol}://x-access-token:$GithubAccessToken@$url_rest"
+elif [[ -n  "$GitlabCIJobToken" ]]; then
+    url_to_use="${protocol}://gitlab-ci-token:$GitlabCIJobToken@$url_rest"
 else
   url_to_use="$url"
 fi

--- a/mkdocs_multirepo_plugin/scripts/sparse_clone_old.sh
+++ b/mkdocs_multirepo_plugin/scripts/sparse_clone_old.sh
@@ -21,6 +21,8 @@ if [[ -n  "$AccessToken" ]]; then
     git config http.extraheader "AUTHORIZATION: bearer $AccessToken"
 elif [[ -n  "$GithubAccessToken" ]]; then
     url_to_use="${protocol}://x-access-token:$GithubAccessToken@$url_rest"
+elif [[ -n  "$GitlabCIJobToken" ]]; then
+    url_to_use="${protocol}://gitlab-ci-token:$GitlabCIJobToken@$url_rest"
 else
   url_to_use="$url"
 fi


### PR DESCRIPTION
Gitlab CI runs have a $CI_JOB_TOKEN (https://docs.gitlab.com/ee/ci/jobs/ci_job_token.html) which needs a different username vs using personal token, which can reuse the format used for github's auth

this only adds an extra case for when CI_JOB_TOKEN exists