### PR TITLE
Improve Git Version Parsing/Checking and Added `mypy`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,12 @@
+exclude: >
+      (?x)(
+          \.mypy_cache/
+          | \.pytest_cache/
+          | \.venv/
+          | build/
+          | dist/
+          | \S+\.egg-info/
+      )
 repos:
   - repo: https://github.com/timothycrosley/isort
     rev: 5.10.1
@@ -25,6 +34,10 @@ repos:
     hooks:
       - id: flake8
         args: ["--select=E9,F63,F7,F82", "--show-source", "--max-complexity=10", "--max-line-length=127", "--statistics"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.10.0'  # Use the sha / tag you want to point at
+    hooks:
+      - id: mypy
   - repo: local
     hooks:
       - id: unit-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.8.1
+
+### Prs in Release
+
+- [Better Git Version Parsing and Checking](https://github.com/jdoiro3/mkdocs-multirepo-plugin/pull/148)
+
 ## 0.8.0
 
 ### Prs in Release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mkdocs-multirepo-plugin"
-version = "0.8.0"
+version = "0.8.1"
 description = "Build documentation in multiple repos into one site."
 authors = ["jdoiro3 <josephdoiron1234@yahoo.com>"]
 license = "MIT"


### PR DESCRIPTION
- The previous way we were parsing the `Git` version number to check if the version was less than `2.25.0` and supported `sparse-checkout` was buggy. This PR should improve it.
- Added a `mypy` pre-commit hook.