### PR TITLE
Check git version correctly

### DIFF
--- a/mkdocs_multirepo_plugin/util.py
+++ b/mkdocs_multirepo_plugin/util.py
@@ -103,7 +103,7 @@ def git_supports_sparse_clone() -> bool:
     """The sparse-checkout was added in 2.25.0
     See RelNotes here: https://github.com/git/git/blob/9005149a4a77e2d3409c6127bf4fd1a0893c3495/Documentation/RelNotes/2.25.0.txt#L67
     """
-    return git_version() < Version(2, 25, 0)
+    return git_version() >= Version(2, 25, 0)
 
 
 async def execute_bash_script(


### PR DESCRIPTION
Sparse clone is supported after 2.25, not before. The comparison was inverted.

This bug was introduced in 0.8.1, this fixes it but a new release should go out as soon as possible.