### PR TITLE
Fix version parsing and Git `sparse-clone` check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Prs in Release
 
-- [Fix Version Parsing](https://github.com/jdoiro3/mkdocs-multirepo-plugin/pull/151)
+- [Fix Version Parsing and Git Version Check](https://github.com/jdoiro3/mkdocs-multirepo-plugin/pull/151)
 
 ## 0.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.8.2
+
+### Prs in Release
+
+- [Fix Version Parsing](https://github.com/jdoiro3/mkdocs-multirepo-plugin/pull/151)
+
 ## 0.8.1
 
 ### Prs in Release

--- a/mkdocs_multirepo_plugin/util.py
+++ b/mkdocs_multirepo_plugin/util.py
@@ -103,7 +103,7 @@ def git_supports_sparse_clone() -> bool:
     """The sparse-checkout was added in 2.25.0
     See RelNotes here: https://github.com/git/git/blob/9005149a4a77e2d3409c6127bf4fd1a0893c3495/Documentation/RelNotes/2.25.0.txt#L67
     """
-    return git_version() < Version(2, 25, 0)
+    return git_version() >= Version(2, 25, 0)
 
 
 async def execute_bash_script(

--- a/mkdocs_multirepo_plugin/util.py
+++ b/mkdocs_multirepo_plugin/util.py
@@ -74,9 +74,9 @@ def parse_version(val: str) -> Version:
     version: str = match.group(1) if match else ""
     major, minor, patch = version.split(".", maxsplit=2)
     return Version(
-        major=int(major.ljust(2, "0")),
-        minor=int(minor.ljust(2, "0")),
-        patch=int(patch.ljust(2, "0")),
+        major=int(major),
+        minor=int(minor),
+        patch=int(patch),
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mkdocs-multirepo-plugin"
-version = "0.8.1"
+version = "0.8.2"
 description = "Build documentation in multiple repos into one site."
 authors = ["jdoiro3 <josephdoiron1234@yahoo.com>"]
 license = "MIT"


### PR DESCRIPTION
- No idea why I thought I needed to do padding when parsing the version. What a silly thing to do.
- `sparse-clone` was added in `2.25` but the comparison was inverted.