### PR TITLE
Fix edit_uri for repos via ssh

### DIFF
--- a/mkdocs_multirepo_plugin/structure.py
+++ b/mkdocs_multirepo_plugin/structure.py
@@ -345,7 +345,7 @@ class DocsRepo(Repo):
             ]
         if self.edit_uri.startswith("http"):
             # If edit_uri starts with http we will use this instead of repo url
-            url_parts.pop()
+            url_parts.pop(0)
         return "/".join(part.strip("/") for part in url_parts)
 
     def set_edit_uri(self, edit_uri) -> None:


### PR DESCRIPTION
This feature didn't work for me. I think that's because ` list.pop([i])` "removes .. the last item in the list" while we want to remove the fist one instead. 

What do you think @auduny?