### PR TITLE
Add support for section_path in nav_repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ plugins:
         - name: fast-api
           import_url: https://github.com/tiangolo/fastapi
           imports: [docs/en/docs/index.md]
+          # Puts the repo in the modules/fast-api directory
+          section_path: modules
 
 nav:
   - Backstage:

--- a/mkdocs_multirepo_plugin/plugin.py
+++ b/mkdocs_multirepo_plugin/plugin.py
@@ -52,7 +52,7 @@ class NavRepoConfig:
     name: str
     import_url: str
     imports: List[str] = field(default_factory=list)
-
+    section_path: Optional[str] = None
 
 @dataclass
 class MultirepoConfig:
@@ -247,7 +247,10 @@ class MultirepoPlugin(BasePlugin):
         docs_repo_objs: List[DocsRepo] = []
         for nr in nav_repos:
             import_stmt = parse_repo_url(nr.import_url)
-            name: str = slugify(nr.name)
+            section_slug: str = slugify(nr.name)
+            path = repo.section_path
+            name = f"{path}/{section_slug}" if path is not None else section_slug
+            
             # mkdocs config values edit_uri and repo_url aren't set
             if need_to_derive_edit_uris:
                 derived_edit_uri = self.derive_config_edit_uri(


### PR DESCRIPTION
Currently, when using `nav_repos`, there is no possibility to specify a custom destination for the included repository. The `slugify()` command removes slashes and hence the directory tree. This patch copies the code from `repos` with a similar behavior.

When using such an approach, a site developer will have to be careful when specifying a path in `nav`
