### PR TITLE
CI: only test python versions `3.9+` since poetry only supports that

### DIFF
--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -51,9 +51,9 @@ jobs:
               var old_pyproject = toml.parse(await fs.readFile('old_pyproject.toml', 'utf8'))
 
               var msg_body = ""
-              if (semver.gte(old_pyproject.project.version, pyproject.project.version)) {
+              if (semver.gte(old_pyproject.tool.poetry.version, pyproject.project.version)) {
                 msg_body = (
-                  `Update the version in [pyproject.toml](https://github.com/${{ github.event.pull_request.head.repo.full_name }}/blob/${{ github.head_ref }}/pyproject.toml) if you want this PR to generate a new release (main is ${old_pyproject.project.version} >= ${pyproject.project.version}).`
+                  `Update the version in [pyproject.toml](https://github.com/${{ github.event.pull_request.head.repo.full_name }}/blob/${{ github.head_ref }}/pyproject.toml) if you want this PR to generate a new release (main is ${old_pyproject.tool.poetry.version} >= ${pyproject.project.version}).`
                   )
               } else {
                 msg_body = "Version has been updated in pyproject.toml."

--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -49,7 +49,8 @@ jobs:
 
               var pyproject = toml.parse(await fs.readFile('pyproject.toml', 'utf8'))
               var old_pyproject = toml.parse(await fs.readFile('old_pyproject.toml', 'utf8'))
-
+              console.log(old_pyproject.tool.poetry.version, pyproject.project.version)
+              
               var msg_body = ""
               if (semver.gte(old_pyproject.tool.poetry.version, pyproject.project.version)) {
                 msg_body = (

--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -51,9 +51,9 @@ jobs:
               var old_pyproject = toml.parse(await fs.readFile('old_pyproject.toml', 'utf8'))
 
               var msg_body = ""
-              if (semver.gte(old_pyproject.tool.poetry.version, pyproject.tool.poetry.version)) {
+              if (semver.gte(old_pyproject.project.version, pyproject.project.version)) {
                 msg_body = (
-                  `Update the version in [pyproject.toml](https://github.com/${{ github.event.pull_request.head.repo.full_name }}/blob/${{ github.head_ref }}/pyproject.toml) if you want this PR to generate a new release (main is ${old_pyproject.tool.poetry.version} >= ${pyproject.tool.poetry.version}).`
+                  `Update the version in [pyproject.toml](https://github.com/${{ github.event.pull_request.head.repo.full_name }}/blob/${{ github.head_ref }}/pyproject.toml) if you want this PR to generate a new release (main is ${old_pyproject.project.version} >= ${pyproject.project.version}).`
                   )
               } else {
                 msg_body = "Version has been updated in pyproject.toml."

--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -49,12 +49,11 @@ jobs:
 
               var pyproject = toml.parse(await fs.readFile('pyproject.toml', 'utf8'))
               var old_pyproject = toml.parse(await fs.readFile('old_pyproject.toml', 'utf8'))
-              console.log(old_pyproject.tool.poetry.version, pyproject.project.version)
               
               var msg_body = ""
-              if (semver.gte(old_pyproject.tool.poetry.version, pyproject.project.version)) {
+              if (semver.gte(old_pyproject.project.version, pyproject.project.version)) {
                 msg_body = (
-                  `Update the version in [pyproject.toml](https://github.com/${{ github.event.pull_request.head.repo.full_name }}/blob/${{ github.head_ref }}/pyproject.toml) if you want this PR to generate a new release (main is ${old_pyproject.tool.poetry.version} >= ${pyproject.project.version}).`
+                  `Update the version in [pyproject.toml](https://github.com/${{ github.event.pull_request.head.repo.full_name }}/blob/${{ github.head_ref }}/pyproject.toml) if you want this PR to generate a new release (main is ${old_pyproject.project.version} >= ${pyproject.project.version}).`
                   )
               } else {
                 msg_body = "Version has been updated in pyproject.toml."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,10 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: Install Poetry
         uses: snok/install-poetry@v1
       - name: Install Python dependencies
@@ -70,8 +70,8 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
-        git-version: [2.17.0, 2.35.0, 2.37.1]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        git-version: ['2.17.0', '2.35.0', '2.37.1']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: Install Poetry
         uses: snok/install-poetry@v1
       - name: Install Python dependencies
@@ -42,7 +42,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         git-version: [2.17.0, 2.35.0, 2.37.1]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,9 @@
 name = "mkdocs-multirepo-plugin"
 version = "0.8.3"
 description = "Build documentation in multiple repos into one site."
-authors = ["jdoiro3 <josephdoiron1234@yahoo.com>"]
+authors = [
+    { name="Joseph Doiron", email="josephdoiron1234@yahoo.com" }
+]
 license = "MIT"
 readme = "README.md"
 homepage = "https://pypi.org/project/mkdocs-multirepo-plugin/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-[tool.poetry]
+[project]
 name = "mkdocs-multirepo-plugin"
 version = "0.8.3"
 description = "Build documentation in multiple repos into one site."


### PR DESCRIPTION
- `poetry` now implements [PEP 621](https://peps.python.org/pep-0621/).
- `poetry` only supports `python` versions `3.9+`.