### PR TITLE
fix ssh import urls to https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.8.4
+
+### Prs in Release
+
+- [Fix SSH urls to HTTPS](https://github.com/jdoiro3/mkdocs-multirepo-plugin/pull/171)
+
 ## 0.8.3
 
 ### Prs in Release

--- a/README.md
+++ b/README.md
@@ -174,6 +174,22 @@ Once you're done configuring, run either `mkdocs serve` or `mkdocs build`. This 
 
 ## Additional Features
 
+### Support ssh urls for import
+
+If an imported repo is imported via an ssh connection, the edit url needs to be modified to reflect an https link.
+
+```
+plugins:
+  - multirepo:
+      cleanup: false
+      repos:
+        - section: Some MKDocs Repo
+          section_path: mkdocs
+          import_url: 'ssh://git@github.com/mkdocs/some-repo?branch=main&edit_uri=blob/main/docs'
+```
+
+This url is modified to remove the `ssh://git@`  or `git@` with `https://` creating the correct edit url.
+
 ### α Multiple Docs Directories in Imported Repo (Alpha)
 
 If an imported repo is a monorepo (i.e., has multiple *docs* directories), *multirepo* automatically includes them in the site when `multi_docs` is set to `True`.

--- a/mkdocs_multirepo_plugin/structure.py
+++ b/mkdocs_multirepo_plugin/structure.py
@@ -308,6 +308,14 @@ class DocsRepo(Repo):
         if self._keep_docs_dir is None:
             return global_keep_docs_dir
         return self._keep_docs_dir
+    
+    def get_https_url(self, source_url: str) -> str:
+        """Converts a git url to an https url"""
+        if source_url.startswith("ssh://"):
+            source_url = source_url.replace("ssh://", "")
+        if source_url.startswith("git@"):
+            source_url = source_url.replace(":", "/").replace("git@", "https://")
+        return source_url
 
     def get_edit_url(
         self, src_path, keep_docs_dir: bool = False, nav_repos: bool = False
@@ -319,14 +327,14 @@ class DocsRepo(Repo):
             if parent_path in self.src_path_map:
                 src_path = Path(src_path)
                 url_parts = [
-                    self.url,
+                    self.get_https_url(self.url),
                     self.edit_uri,
                     self.src_path_map.get(parent_path),
                     str(src_path.name),
                 ]
             else:
                 url_parts = [
-                    self.url,
+                    self.get_https_url(self.url),
                     self.edit_uri,
                     self.src_path_map.get(str(src_path), str(src_path)),
                 ]
@@ -335,10 +343,10 @@ class DocsRepo(Repo):
             or self.keep_docs_dir(global_keep_docs_dir=keep_docs_dir)
             or nav_repos
         ):
-            url_parts = [self.url, self.edit_uri, src_path]
+            url_parts = [self.get_https_url(self.url), self.edit_uri, src_path]
         else:
             url_parts = [
-                self.url,
+                self.get_https_url(self.url),
                 self.edit_uri,
                 self.docs_dir.replace("/*", ""),
                 src_path,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mkdocs-multirepo-plugin"
-version = "0.8.3"
+version = "0.8.4"
 description = "Build documentation in multiple repos into one site."
 authors = [
     { name="Joseph Doiron", email="josephdoiron1234@yahoo.com" }


### PR DESCRIPTION
This edit detects ssh://git@ and git@ urls, and replaces it with https:// in the get_edit_url function. Readme updated to include example.